### PR TITLE
Explicitly add retworkx to requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.17
 qiskit-terra>=0.19
+retworkx>=0.10.2

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 REQUIREMENTS = ['numpy>=1.17',
                 'qiskit-terra>=0.19',
+                'retworkx>0.10.2',
                ]
 
 PACKAGES = setuptools.find_namespace_packages()


### PR DESCRIPTION
This commit explicitly adds retworkx to the requirements list. While
retworkx is a core dependency of qiskit-terra which was already in the
requirements list it is also directly imported in the mapomatic code.
It's standard best practice to include all directly imported
dependencies in the requirements list. This is for two reasons, the
first is to give a lever over required versions. The needs of mapomatic
may diverge from qiskit-terra's and mapomatic may at some point require
a more specific version than qiskit's so having a dedicated requirement
entry enables this. The other reason likely won't apply here, but if
qiskit ever drops retworkx as a requirement mapomatic would still
require it and the package wouldn't be installed.