### PR TITLE
Fix support for multiple registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ One of the main painpoints in executing circuits on IBM Quantum hardware is find
 
 ## Usage
 
-> **IMPORTANT**: `mapomatic` currently works only on circuits with single quantum and classical registers
-
 To begin we first import what we need and load our IBM Quantum account.
 
 ```python

--- a/mapomatic/mappings.py
+++ b/mapomatic/mappings.py
@@ -148,12 +148,12 @@ def best_mapping(circ, backends, successors=False, call_limit=100):
                     fid = 1
                     for item in circ._data:
                         if item[0].name == 'cx':
-                            q0 = item[1][0]._index
-                            q1 = item[1][1]._index
+                            q0 = circ.find_bit(item[1][0]).index
+                            q1 = circ.find_bit(item[1][1]).index
                             fid *= (1-props.gate_error('cx', [vir_phys_layout[q0],
                                                               vir_phys_layout[q1]]))
                         if item[0].name == 'measure':
-                            q0 = item[1][0]._index
+                            q0 = circ.find_bit(item[1][0]).index
                             fid *= 1-props.readout_error(vir_phys_layout[q0])
                     error = 1-fid
                     if error < system_best_error:

--- a/mapomatic/tests/__init__.py
+++ b/mapomatic/tests/__init__.py
@@ -1,0 +1,11 @@
+# This code is part of Mapomatic.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.

--- a/mapomatic/tests/test_best_mapping.py
+++ b/mapomatic/tests/test_best_mapping.py
@@ -1,0 +1,68 @@
+# This code is part of Mapomatic.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import numpy as np
+import pytest
+from qiskit import transpile, QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.test.mock import FakeBelem, FakeQuito, FakeLima
+
+import mapomatic as mm
+
+def test_best_mapping_ghz_state_full_device_multiple_qregs():
+    qr_a = QuantumRegister(2)
+    qr_b = QuantumRegister(3)
+    qc = QuantumCircuit(qr_a, qr_b)
+    qc.h(qr_a[0])
+    qc.cx(qr_a[0], qr_a[1])
+    qc.cx(qr_a[0], qr_b[0])
+    qc.cx(qr_a[0], qr_b[1])
+    qc.cx(qr_a[0], qr_b[2])
+    qc.measure_all()
+    trans_qc = transpile(qc, FakeLima(), seed_transpiler=102442)
+    backends = [FakeBelem(), FakeQuito(), FakeLima()]
+    res = mm.best_mapping(trans_qc, backends, successors=True)
+    expected_res = [
+        ([0, 1, 2, 3, 4], 'fake_lima', 0.294),
+        ([0, 1, 2, 3, 4], 'fake_belem', 0.309),
+        ([2, 1, 0, 3, 4], 'fake_quito', 0.535)
+    ]
+    for index, expected in enumerate(expected_res):
+        assert res[index][0] == expected[0]
+        assert res[index][1] == expected[1]
+        assert res[index][2] == pytest.approx(expected[2], 0.01)
+
+
+def test_best_mapping_ghz_state_deflate_multiple_registers():
+    qr_a = QuantumRegister(2)
+    qr_b = QuantumRegister(2)
+    cr_a = ClassicalRegister(2)
+    cr_b = ClassicalRegister(2)
+    qc = QuantumCircuit(qr_a, qr_b, cr_a, cr_b)
+    qc.h(qr_a[0])
+    qc.cx(qr_a[0], qr_a[1])
+    qc.cx(qr_a[0], qr_b[0])
+    qc.cx(qr_a[0], qr_b[1])
+    qc.measure(qr_a, cr_b)
+    qc.measure(qr_b, cr_a)
+    trans_qc = transpile(qc, FakeLima(), seed_transpiler=102442)
+    small_circ = mm.deflate_circuit(trans_qc)
+    backends = [FakeBelem(), FakeQuito(), FakeLima()]
+    res = mm.best_mapping(small_circ, backends, successors=True)
+    expected_res = [
+        ([3, 1, 0, 2], 'fake_lima', 0.146),
+        ([3, 1, 0, 2], 'fake_belem', 0.187),
+        ([2, 1, 3, 0], 'fake_quito', 0.32)
+    ]
+    for index, expected in enumerate(expected_res):
+        assert res[index][0] == expected[0]
+        assert res[index][1] == expected[1]
+        assert res[index][2] == pytest.approx(expected[2], 0.01)


### PR DESCRIPTION
This commit fixes support for working with multiple registers in
mapomatic. To do this instead of working with bit indices (which is the
more natural way to think about them) this instead works with Qiskit bit
objects which are standalone and don't have an order outside of the
circuit. Whenever an order is needed the QuantumCircuit.find_bit() api is
used to get the bit's index and uses that. This then adds tests with
multiple registers to verify this works.