### PR TITLE
Return sorted lists by exact_mappings

### DIFF
--- a/mapomatic/mappings.py
+++ b/mapomatic/mappings.py
@@ -108,10 +108,10 @@ def exact_mappings(circ, cmap, strict_direction=False, call_limit=10000):
 
 def unique_subsets(mappings):
     """Unique subset of qubits in mappings.
-    
+
     Parameters:
         mappings (list): Collection of possible mappings
-    
+
     Returns:
         list: Unique sets of qubits
     """

--- a/mapomatic/mappings.py
+++ b/mapomatic/mappings.py
@@ -118,7 +118,7 @@ def unique_subsets(mappings):
     sets = []
     for mapping in mappings:
         temp = set(mapping)
-        if not temp in sets:
+        if temp not in sets:
             sets.append(temp)
     return sets
 

--- a/mapomatic/mappings.py
+++ b/mapomatic/mappings.py
@@ -94,7 +94,6 @@ def exact_mappings(circ, cmap, strict_direction=False, call_limit=100):
         call_limit=call_limit,
     )
     layouts = []
-    temp_sets = []
     for mapping in mappings:
         # Here we sort in the order that we would use
         # for intial layout
@@ -103,12 +102,7 @@ def exact_mappings(circ, cmap, strict_direction=False, call_limit=100):
             key = qubits[im_i]
             val = cm_nodes[cm_i]
             temp_list[circ.find_bit(key).index] = val
-        temp_set = set(temp_list)
-        # VF2 returns lots of permutations of subgraphs
-        # If the set has already been added, do not add again
-        if temp_set not in temp_sets:
-            layouts.append(temp_list)
-            temp_sets.append(temp_set)
+        layouts.append(temp_list)
     return layouts
 
 

--- a/mapomatic/mappings.py
+++ b/mapomatic/mappings.py
@@ -96,7 +96,7 @@ def exact_mappings(circ, cmap, strict_direction=False, call_limit=100):
     layouts = []
     temp_sets = []
     for mapping in mappings:
-        # Here we sort in the order that we would use 
+        # Here we sort in the order that we would use
         # for intial layout
         temp_list = [None]*circ.num_qubits
         for cm_i, im_i in mapping.items():
@@ -132,7 +132,6 @@ def best_mapping(circ, backends, successors=False, call_limit=100):
     best_error = np.inf
     best_layout = None
     best_backend = None
-    initial_layout = None
     mappings = {}
     best_out = []
 

--- a/mapomatic/mappings.py
+++ b/mapomatic/mappings.py
@@ -35,7 +35,7 @@ from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.coupling import CouplingMap
 
 
-def exact_mappings(circ, cmap, strict_direction=False, call_limit=100):
+def exact_mappings(circ, cmap, strict_direction=False, call_limit=10000):
     """Find the exact mappings for a circuit onto a given topology (coupling map)
 
     Parameters:
@@ -106,7 +106,24 @@ def exact_mappings(circ, cmap, strict_direction=False, call_limit=100):
     return layouts
 
 
-def best_mapping(circ, backends, successors=False, call_limit=100):
+def unique_subsets(mappings):
+    """Unique subset of qubits in mappings.
+    
+    Parameters:
+        mappings (list): Collection of possible mappings
+    
+    Returns:
+        list: Unique sets of qubits
+    """
+    sets = []
+    for mapping in mappings:
+        temp = set(mapping)
+        if not temp in sets:
+            sets.append(temp)
+    return sets
+
+
+def best_mapping(circ, backends, successors=False, call_limit=10000):
     """Find the best selection of qubits and system to run
     the chosen circuit one.
 

--- a/mapomatic/tests/test_subgraphs.py
+++ b/mapomatic/tests/test_subgraphs.py
@@ -17,8 +17,8 @@ from qiskit.test.mock import FakeMontreal
 import mapomatic as mm
 
 
-def test_test_find_all_subgraphs():
-    """Test that all unique subgraphs can be found"""
+def test_test_find_all_subsets():
+    """Test that all unique subset can be found"""
     qc = QuantumCircuit(4)
     qc.h(0)
     qc.cx(0, 1)
@@ -28,17 +28,18 @@ def test_test_find_all_subgraphs():
 
     backend = FakeMontreal()
     mappings = mm.mappings.exact_mappings(qc, backend.configuration().coupling_map)
+    unique_sets = mm.mappings.unique_subsets(mappings)    
 
-    assert len(mappings) == 7
+    assert len(unique_sets) == 8
 
-    ans_list = [[1, 2, 4, 0],
-                [7, 4, 10, 6],
-                [8, 5, 11, 9],
-                [12, 10, 13, 15],
-                [14, 11, 13, 16],
-                [18, 15, 21, 17],
-                [19, 16, 22, 20],
-                [25, 22, 24, 26]]
+    ans_list = [set([1, 2, 4, 0]),
+                set([7, 4, 10, 6]),
+                set([8, 5, 11, 9]),
+                set([12, 10, 13, 15]),
+                set([14, 11, 13, 16]),
+                set([18, 15, 21, 17]),
+                set([19, 16, 22, 20]),
+                set([25, 22, 24, 26])]
 
-    for mapping in mappings:
-        assert mapping in ans_list
+    for st in unique_sets:
+        assert st in ans_list

--- a/mapomatic/tests/test_subgraphs.py
+++ b/mapomatic/tests/test_subgraphs.py
@@ -11,8 +11,7 @@
 # that they have been altered from the originals.
 """Test best mappings"""
 
-import pytest
-from qiskit import transpile, QuantumCircuit
+from qiskit import QuantumCircuit
 from qiskit.test.mock import FakeMontreal
 
 import mapomatic as mm

--- a/mapomatic/tests/test_subgraphs.py
+++ b/mapomatic/tests/test_subgraphs.py
@@ -1,0 +1,45 @@
+# This code is part of Mapomatic.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Test best mappings"""
+
+import pytest
+from qiskit import transpile, QuantumCircuit
+from qiskit.test.mock import FakeMontreal
+
+import mapomatic as mm
+
+
+def test_test_find_all_subgraphs():
+    """Test that all unique subgraphs can be found"""
+    qc = QuantumCircuit(4)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(0, 2)
+    qc.cx(0, 3)
+    qc.measure_all()
+
+    backend = FakeMontreal()
+    mappings = mm.mappings.exact_mappings(qc, backend.configuration().coupling_map)
+
+    assert len(mappings) == 7
+
+    ans_list = [[1, 2, 4, 0],
+                [7, 4, 10, 6],
+                [8, 5, 11, 9],
+                [12, 10, 13, 15],
+                [14, 11, 13, 16],
+                [18, 15, 21, 17],
+                [19, 16, 22, 20],
+                [25, 22, 24, 26]]
+
+    for mapping in mappings:
+        assert mapping in ans_list

--- a/mapomatic/tests/test_subgraphs.py
+++ b/mapomatic/tests/test_subgraphs.py
@@ -28,7 +28,7 @@ def test_test_find_all_subsets():
 
     backend = FakeMontreal()
     mappings = mm.mappings.exact_mappings(qc, backend.configuration().coupling_map)
-    unique_sets = mm.mappings.unique_subsets(mappings)    
+    unique_sets = mm.mappings.unique_subsets(mappings)
 
     assert len(unique_sets) == 8
 


### PR DESCRIPTION
Return mappings as lists that are sorted for use by `initial_layout`

Also had to bump `call_limit` to `1000` as otherwise VF2 was always missing a subgraph on the 27Q layout