### PR TITLE
Better api

### DIFF
--- a/mapomatic/__init__.py
+++ b/mapomatic/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
     __version__ = '0.0.0'
 
 from .circuits import deflate_circuit
-from .mappings import best_mapping
+from .layouts import (best_overall_layout, matching_layouts, evaluate_layouts)
 
 
 def about():

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -177,9 +177,6 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000):
     if not isinstance(backends, list):
         backends = [backends]
 
-    best_error = np.inf
-    best_layout = None
-    best_backend = None
     layouts = {}
     best_out = []
 
@@ -187,7 +184,6 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000):
     for backend in backends:
         config = backend.configuration()
         num_qubits = config.num_qubits
-        backend_name = backend.name()
         if not config.simulator and circ_qubits <= num_qubits:
             seg = config.processor_type.get('segment', '')
             key = str(num_qubits)+seg

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -27,6 +27,7 @@
 # that they have been altered from the originals.
 
 """Circuit manipulation tools"""
+from ftplib import error_proto
 import random
 import numpy as np
 
@@ -35,8 +36,8 @@ from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.coupling import CouplingMap
 
 
-def exact_mappings(circ, cmap, strict_direction=False, call_limit=10000):
-    """Find the exact mappings for a circuit onto a given topology (coupling map)
+def matching_layouts(circ, cmap, strict_direction=False, call_limit=10000):
+    """Matching for a circuit onto a given topology (coupling map)
 
     Parameters:
         circ (QuantumCircuit): Input quantum circuit
@@ -123,7 +124,41 @@ def unique_subsets(mappings):
     return sets
 
 
-def best_mapping(circ, backends, successors=False, call_limit=10000):
+def evaluate_layouts(circ, layouts, backend):
+    """Evaluate the error rate of the layout on a backend
+
+    Parameters:
+        circ (QuantumCircuit): circuit of interest
+        layouts (list): Specified layouts
+        backend (IBMQBackend): An IBM Quantum backend instance
+
+    Returns:
+        list: Tuples of layouts and errors
+    """
+    # Make a single layout nested
+    if not isinstance(layouts[0], list):
+        layouts = [layouts]
+    out = []
+    props = backend.properties()
+    for layout in layouts:
+        error = 0
+        fid = 1
+        for item in circ._data:
+            if item[0].name == 'cx':
+                q0 = circ.find_bit(item[1][0]).index
+                q1 = circ.find_bit(item[1][1]).index
+                fid *= (1-props.gate_error('cx', [layout[q0],
+                                                  layout[q1]]))
+            if item[0].name == 'measure':
+                q0 = circ.find_bit(item[1][0]).index
+                fid *= 1-props.readout_error(layout[q0])
+        error = 1-fid
+        out.append((layout, error))
+    out.sort(key=lambda x: x[1])
+    return out
+
+
+def best_overall_layout(circ, backends, successors=False, call_limit=10000):
     """Find the best selection of qubits and system to run
     the chosen circuit one.
 
@@ -143,7 +178,7 @@ def best_mapping(circ, backends, successors=False, call_limit=10000):
     best_error = np.inf
     best_layout = None
     best_backend = None
-    mappings = {}
+    layouts = {}
     best_out = []
 
     circ_qubits = circ.num_qubits
@@ -151,42 +186,15 @@ def best_mapping(circ, backends, successors=False, call_limit=10000):
         config = backend.configuration()
         num_qubits = config.num_qubits
         backend_name = backend.name()
-
         if not config.simulator and circ_qubits <= num_qubits:
             seg = config.processor_type.get('segment', '')
             key = str(num_qubits)+seg
-            if key not in mappings:
-                mappings[key] = exact_mappings(circ, config.coupling_map,
-                                               call_limit=call_limit)
-            props = backend.properties()
-            system_best_layout = None
-            system_best_error = np.inf
-            if any(mappings[key]):
-                for mapping in mappings[key]:
-                    error = 0
-                    fid = 1
-                    for item in circ._data:
-                        if item[0].name == 'cx':
-                            q0 = circ.find_bit(item[1][0]).index
-                            q1 = circ.find_bit(item[1][1]).index
-                            fid *= (1-props.gate_error('cx', [mapping[q0],
-                                                              mapping[q1]]))
-                        if item[0].name == 'measure':
-                            q0 = circ.find_bit(item[1][0]).index
-                            fid *= 1-props.readout_error(mapping[q0])
-                    error = 1-fid
-                    if error < system_best_error:
-                        system_best_layout = mapping
-                        system_best_error = error
-                    if error < best_error:
-                        best_error = error
-                        best_layout = mapping
-                        best_backend = backend_name
-
-                best_out.append((system_best_layout, backend_name, system_best_error))
-    if best_layout:
-        if not successors:
-            return best_layout, best_backend, best_error
-        best_out.sort(key=lambda x: x[2])
-        return best_out
-    return []
+            if key not in layouts:
+                layouts[key] = matching_layouts(circ, config.coupling_map,
+                                                call_limit=call_limit)
+            layout, error = evaluate_layouts(circ, layouts[key], backend)[0]
+            best_out.append((layout, backend.name(), error))
+    best_out.sort(key=lambda x: x[2])
+    if not successors:
+        return best_out[0]
+    return best_out

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -27,9 +27,7 @@
 # that they have been altered from the originals.
 
 """Circuit manipulation tools"""
-from ftplib import error_proto
 import random
-import numpy as np
 
 from retworkx import PyGraph, PyDiGraph, vf2_mapping
 from qiskit.converters import circuit_to_dag

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -135,10 +135,12 @@ def evaluate_layouts(circ, layouts, backend):
     Returns:
         list: Tuples of layouts and errors
     """
-    # Make a single layout nested
+    if not any(layouts):
+        return []
     if not isinstance(layouts[0], list):
         layouts = [layouts]
     out = []
+    # Make a single layout nested
     props = backend.properties()
     for layout in layouts:
         error = 0
@@ -192,9 +194,12 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000):
             if key not in layouts:
                 layouts[key] = matching_layouts(circ, config.coupling_map,
                                                 call_limit=call_limit)
-            layout, error = evaluate_layouts(circ, layouts[key], backend)[0]
-            best_out.append((layout, backend.name(), error))
+            layout_and_error = evaluate_layouts(circ, layouts[key], backend)
+            if any(layout_and_error):
+                layout = layout_and_error[0][0]
+                error = layout_and_error[0][1]
+                best_out.append((layout, backend.name(), error))
     best_out.sort(key=lambda x: x[2])
-    if not successors:
-        return best_out[0]
-    return best_out
+    if successors:
+        return best_out
+    return best_out[0]

--- a/mapomatic/tests/test_best_mapping.py
+++ b/mapomatic/tests/test_best_mapping.py
@@ -31,7 +31,7 @@ def test_best_mapping_ghz_state_full_device_multiple_qregs():
     qc.measure_all()
     trans_qc = transpile(qc, FakeLima(), seed_transpiler=102442)
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
-    res = mm.best_mapping(trans_qc, backends, successors=True)
+    res = mm.best_overall_layout(trans_qc, backends, successors=True)
     expected_res = [
         ([0, 1, 2, 3, 4], 'fake_lima', 0.294),
         ([0, 1, 2, 3, 4], 'fake_belem', 0.309),
@@ -59,7 +59,7 @@ def test_best_mapping_ghz_state_deflate_multiple_registers():
     trans_qc = transpile(qc, FakeLima(), seed_transpiler=102442)
     small_circ = mm.deflate_circuit(trans_qc)
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
-    res = mm.best_mapping(small_circ, backends, successors=True)
+    res = mm.best_overall_layout(small_circ, backends, successors=True)
     expected_res = [
         ([3, 1, 0, 2], 'fake_lima', 0.146),
         ([3, 1, 0, 2], 'fake_belem', 0.187),

--- a/mapomatic/tests/test_subgraphs.py
+++ b/mapomatic/tests/test_subgraphs.py
@@ -27,7 +27,7 @@ def test_test_find_all_subsets():
     qc.measure_all()
 
     backend = FakeMontreal()
-    mappings = mm.mappings.exact_mappings(qc, backend.configuration().coupling_map)
+    mappings = mm.matching_layouts(qc, backend.configuration().coupling_map)
     unique_sets = mm.mappings.unique_subsets(mappings)
 
     assert len(unique_sets) == 8

--- a/mapomatic/tests/test_subgraphs.py
+++ b/mapomatic/tests/test_subgraphs.py
@@ -28,7 +28,7 @@ def test_test_find_all_subsets():
 
     backend = FakeMontreal()
     mappings = mm.matching_layouts(qc, backend.configuration().coupling_map)
-    unique_sets = mm.mappings.unique_subsets(mappings)
+    unique_sets = mm.layouts.unique_subsets(mappings)
 
     assert len(unique_sets) == 8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-numpy>=1.17
 qiskit-terra>=0.19
 retworkx>=0.10.2

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ import setuptools
 
 
 MAJOR = 0
-MINOR = 0
-MICRO = 1
+MINOR = 1
+MICRO = 0
 
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)


### PR DESCRIPTION
fixes #6 

Makes the API a bit cleaner allowing for users to explicitly access all parts of the computation.

Namely, for getting all the layouts that match a circuit (deflated or not) there is `matching_layouts`. For evaluating a given layout(s) on a backend there is `evaluate_layouts`.  And the best layout over one or more backends is now called `best_overall_layout` to be explicit.

Bumped the version to `0.1` as I think this all makes sense.