### PR TITLE
Remove numpy from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
-REQUIREMENTS = ['numpy>=1.17',
-                'qiskit-terra>=0.19',
+REQUIREMENTS = ['qiskit-terra>=0.19',
                 'retworkx>0.10.2',
                ]
 


### PR DESCRIPTION
NumPy was removed from the requirements, but I forgot about it in setup.