### PR TITLE
Add tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+minversion = 2.1
+envlist = py310,py39,py38,py37,lint
+skipsdist = True
+
+[testenv]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+deps =
+  -r{toxinidir}/requirements-dev.txt
+commands = pytest {posargs}
+
+[testenv:lint]
+envdir = .tox/lint
+commands =
+  pylint -rn -j 0 --rcfile={toxinidir}/.pylintrc mapomatic/
+
+[testenv:docs]
+commands =
+  sphinx-build -b html -W {posargs} docs/ docs/_build/html
+
+[pycodestyle]
+max-line-length = 100


### PR DESCRIPTION
To simplify running tests for local developers this commit adds a
a tox.ini file. Tox enables a single entrypoint that combines venv
management with running test commands. Local developers can leverage
this to automate the execution of tests and installing mapomatic in an
isolated venv when making local changes.