### PR TITLE
Allow for deflating scheduled circuits

### DIFF
--- a/mapomatic/circuits.py
+++ b/mapomatic/circuits.py
@@ -53,7 +53,7 @@ def deflate_circuit(input_circ):
 
     new_qc = QuantumCircuit(num_reduced_qubits, num_reduced_clbits)
     for item in input_circ.data:
-        if all([qubit in active_qubits for qubit in item[1]]):
+        if all(qubit in active_qubits for qubit in item[1]):
             ref = getattr(new_qc, item[0].name)
             params = item[0].params
             qargs = [new_qc.qubits[active_map[qubit]] for qubit in item[1]]

--- a/mapomatic/circuits.py
+++ b/mapomatic/circuits.py
@@ -30,7 +30,7 @@ def deflate_circuit(input_circ):
     active_qubits = set([])
     active_clbits = set([])
     for item in input_circ.data:
-        if item[0].name not in ["barrier"]:
+        if item[0].name not in ["barrier", "delay"]:
             qubits = item[1]
             for qubit in qubits:
                 active_qubits.add(qubit)
@@ -53,7 +53,7 @@ def deflate_circuit(input_circ):
 
     new_qc = QuantumCircuit(num_reduced_qubits, num_reduced_clbits)
     for item in input_circ.data:
-        if item[0].name not in ["barrier"]:
+        if all([qubit in active_qubits for qubit in item[1]]):
             ref = getattr(new_qc, item[0].name)
             params = item[0].params
             qargs = [new_qc.qubits[active_map[qubit]] for qubit in item[1]]


### PR DESCRIPTION
Allow for deflating scheduled circuits by ignoring `delays` in the search for active qubits, but then adding them to the deflated circuit like any other instruction (save for barriers).