### PR TITLE
[WIP] Add idle errors to layout cost

### DIFF
--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -164,13 +164,13 @@ def evaluate_layouts(circ, layouts, backend):
             elif item[0].name == 'measure':
                 q0 = circ.find_bit(item[1][0]).index
                 fid *= 1-props.readout_error(layout[q0])
-                
+
             elif item[0].name == 'delay':
                 q0 = circ.find_bit(item[1][0]).index
                 time = item[0].duration * dt
                 qubit = layout[q0]
                 fid *= 1-_idle_error(time, t1s[qubit], t2s[qubit])
-                
+
         error = 1-fid
         out.append((layout, error))
     out.sort(key=lambda x: x[1])
@@ -220,17 +220,16 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000):
 
 def _idle_error(time, t1, t2):
     """Compute the approx. idle error from T1 and T2
-    
+
     Parameters:
         time (float): Delay time in sec
         t1 (float): T1 time in sec
         t2, (float): T2 time in sec
-    
+
     Returns:
         float: Idle error
     """
-    if t2 > t1:
-        t2 = t1
+    t2 = min(t1, t2)
     rate1 = 1/t1
     rate2 = 1/t2
     p_reset = 1-exp(-time*rate1)

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -28,6 +28,7 @@
 
 """Circuit manipulation tools"""
 import random
+from math import exp
 
 from retworkx import PyGraph, PyDiGraph, vf2_mapping
 from qiskit.converters import circuit_to_dag
@@ -39,13 +40,15 @@ def matching_layouts(circ, cmap, strict_direction=False, call_limit=10000):
 
     Parameters:
         circ (QuantumCircuit): Input quantum circuit
-        cmap (list): Coupling map
+        cmap (list or IBMQBackend): Coupling map or backend containing coupling map
         strict_direction (bool): Use directed coupling
         call_limit (int): Max number of calls to VF2 mapper
 
     Returns:
         list: Found mappings.
     """
+    if not isinstance(cmap, list):
+        cmap = cmap.configuration().coupling_map
     dag = circuit_to_dag(circ)
     qubits = dag.qubits
     qubit_indices = {qubit: index for index, qubit in enumerate(qubits)}
@@ -140,6 +143,10 @@ def evaluate_layouts(circ, layouts, backend):
     out = []
     # Make a single layout nested
     props = backend.properties()
+    dt = backend.configuration().dt
+    num_qubits = backend.configuration().num_qubits
+    t1s = [props.qubit_property(qq, 'T1')[0] for qq in range(num_qubits)]
+    t2s = [props.qubit_property(qq, 'T2')[0] for qq in range(num_qubits)]
     for layout in layouts:
         error = 0
         fid = 1
@@ -157,6 +164,13 @@ def evaluate_layouts(circ, layouts, backend):
             elif item[0].name == 'measure':
                 q0 = circ.find_bit(item[1][0]).index
                 fid *= 1-props.readout_error(layout[q0])
+                
+            elif item[0].name == 'delay':
+                q0 = circ.find_bit(item[1][0]).index
+                time = item[0].duration * dt
+                qubit = layout[q0]
+                fid *= 1-_idle_error(time, t1s[qubit], t2s[qubit])
+                
         error = 1-fid
         out.append((layout, error))
     out.sort(key=lambda x: x[1])
@@ -202,3 +216,23 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000):
     if successors:
         return best_out
     return best_out[0]
+
+
+def _idle_error(time, t1, t2):
+    """Compute the approx. idle error from T1 and T2
+    
+    Parameters:
+        time (float): Delay time in sec
+        t1 (float): T1 time in sec
+        t2, (float): T2 time in sec
+    
+    Returns:
+        float: Idle error
+    """
+    if t2 > t1:
+        t2 = t1
+    rate1 = 1/t1
+    rate2 = 1/t2
+    p_reset = 1-exp(-time*rate1)
+    p_z = (1-p_reset)*(1-exp(-time*(rate2-rate1)))/2
+    return p_z + p_reset

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -150,7 +150,7 @@ def evaluate_layouts(circ, layouts, backend):
     t1s = [props.qubit_property(qq, 'T1')[0] for qq in range(num_qubits)]
     t2s = [props.qubit_property(qq, 'T2')[0] for qq in range(num_qubits)]
     for layout in layouts:
-        sch_circ = transpile(circ, backend, initial_layout = layout,
+        sch_circ = transpile(circ, backend, initial_layout=layout,
                              optimization_level=0, scheduling_method='alap')
         error = 0
         fid = 1

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -27,7 +27,6 @@
 # that they have been altered from the originals.
 
 """Circuit manipulation tools"""
-from pickletools import optimize
 import random
 from math import exp
 

--- a/mapomatic/tests/test_best_layout.py
+++ b/mapomatic/tests/test_best_layout.py
@@ -32,9 +32,9 @@ def test_best_mapping_ghz_state_full_device_multiple_qregs():
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
     res = mm.best_overall_layout(trans_qc, backends, successors=True)
     expected_res = [
-        [([2, 1, 0, 3, 4], 'fake_belem', 0.4150109526706456),
-         ([0, 1, 2, 3, 4], 'fake_lima', 0.46177764990686654),
-         ([2, 1, 0, 3, 4], 'fake_quito', 0.6335024069223241)]
+        ([2, 1, 0, 3, 4], 'fake_belem', 0.4150109526706456),
+        ([0, 1, 2, 3, 4], 'fake_lima', 0.46177764990686654),
+        ([2, 1, 0, 3, 4], 'fake_quito', 0.6335024069223241)
     ]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]

--- a/mapomatic/tests/test_best_layout.py
+++ b/mapomatic/tests/test_best_layout.py
@@ -32,9 +32,9 @@ def test_best_mapping_ghz_state_full_device_multiple_qregs():
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
     res = mm.best_overall_layout(trans_qc, backends, successors=True)
     expected_res = [
-        ([0, 1, 2, 3, 4], 'fake_lima', 0.2948138379010775),
-        ([0, 1, 2, 3, 4], 'fake_belem', 0.3099503939385677),
-        ([2, 1, 0, 3, 4], 'fake_quito', 0.5360875795095078)
+        [([2, 1, 0, 3, 4], 'fake_belem', 0.4150109526706456),
+         ([0, 1, 2, 3, 4], 'fake_lima', 0.46177764990686654),
+         ([2, 1, 0, 3, 4], 'fake_quito', 0.6335024069223241)]
     ]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]
@@ -60,9 +60,9 @@ def test_best_mapping_ghz_state_deflate_multiple_registers():
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
     res = mm.best_overall_layout(small_circ, backends, successors=True)
     expected_res = [
-        ([3, 1, 0, 2], 'fake_lima', 0.1466490604029853),
-        ([0, 1, 3, 2], 'fake_belem', 0.18757249682201993),
-        ([3, 1, 2, 0], 'fake_quito', 0.3202504720264385)
+        ([3, 1, 0, 2], 'fake_lima', 0.16555704545051042),
+        ([3, 1, 0, 2], 'fake_belem', 0.21497431066677175),
+        ([3, 1, 2, 0], 'fake_quito', 0.35663459001880293)
     ]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]


### PR DESCRIPTION
Schedules the circuit for each layout and computes the additional error due to idle periods from `delay` instructions.  If the `delay` is before any other instruction then do not count it as qubits in ground state.