### PR TITLE
Add ability to specify custom cost functions easily

### DIFF
--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -122,8 +122,76 @@ def unique_subsets(mappings):
     return sets
 
 
-def evaluate_layouts(circ, layouts, backend):
+def evaluate_layouts(circ, layouts, backend, cost_function=None):
     """Evaluate the error rate of the layout on a backend
+
+    Parameters:
+        circ (QuantumCircuit): circuit of interest
+        layouts (list): Specified layouts
+        backend (IBMQBackend): An IBM Quantum backend instance
+        cost_function (callable): Custom cost function, default=None
+
+    Returns:
+        list: Tuples of layouts, backend name, and errors
+    """
+    if not any(layouts):
+        return []
+    if not isinstance(layouts[0], list):
+        layouts = [layouts]
+    if cost_function is None:
+       cost_func = default_cost
+    out = cost_func(circ, layouts, backend)
+    return out
+
+
+def best_overall_layout(circ, backends, successors=False, call_limit=10000, cost_function=None):
+    """Find the best selection of qubits and system to run
+    the chosen circuit one.
+
+    Parameters:
+        circ (QuantumCircuit): Quantum circuit
+        backends (IBMQBackend or list): A single or list of backends.
+        successors (bool): Return list best mappings per backend passed.
+        call_limit (int): Maximum number of calls to VF2 mapper.
+        cost_function (callable): Custom cost function, default=None
+
+    Returns:
+        tuple: (best_layout, best_backend, best_error)
+        list: List of tuples for best match for each backend
+    """
+    if not isinstance(backends, list):
+        backends = [backends]
+
+    if cost_function is None:
+       cost_func = default_cost
+
+    layouts = {}
+    best_out = []
+
+    circ_qubits = circ.num_qubits
+    for backend in backends:
+        config = backend.configuration()
+        num_qubits = config.num_qubits
+        if not config.simulator and circ_qubits <= num_qubits:
+            seg = config.processor_type.get('segment', '')
+            key = str(num_qubits)+seg
+            if key not in layouts:
+                layouts[key] = matching_layouts(circ, config.coupling_map,
+                                                call_limit=call_limit)
+            layout_and_error = evaluate_layouts(circ, layouts[key], backend, cost_function=cost_func)
+            if any(layout_and_error):
+                layout = layout_and_error[0][0]
+                error = layout_and_error[0][1]
+                best_out.append((layout, backend.name(), error))
+    best_out.sort(key=lambda x: x[2])
+    if successors:
+        return best_out
+    return best_out[0]
+
+
+def default_cost(circ, layouts, backend):
+    """The default mapomatic cost function that returns the total
+    error rate over all the layouts for the gates in the given circuit
 
     Parameters:
         circ (QuantumCircuit): circuit of interest
@@ -131,12 +199,8 @@ def evaluate_layouts(circ, layouts, backend):
         backend (IBMQBackend): An IBM Quantum backend instance
 
     Returns:
-        list: Tuples of layouts and errors
+        list: Tuples of layouts, backend name, and errors
     """
-    if not any(layouts):
-        return []
-    if not isinstance(layouts[0], list):
-        layouts = [layouts]
     out = []
     # Make a single layout nested
     props = backend.properties()
@@ -161,44 +225,3 @@ def evaluate_layouts(circ, layouts, backend):
         out.append((layout, error))
     out.sort(key=lambda x: x[1])
     return out
-
-
-def best_overall_layout(circ, backends, successors=False, call_limit=10000):
-    """Find the best selection of qubits and system to run
-    the chosen circuit one.
-
-    Parameters:
-        circ (QuantumCircuit): Quantum circuit
-        backends (IBMQBackend or list): A single or list of backends.
-        successors (bool): Return list best mappings per backend passed.
-        call_limit (int): Maximum number of calls to VF2 mapper.
-
-    Returns:
-        tuple: (best_layout, best_backend, best_error)
-        list: List of tuples for best match for each backend
-    """
-    if not isinstance(backends, list):
-        backends = [backends]
-
-    layouts = {}
-    best_out = []
-
-    circ_qubits = circ.num_qubits
-    for backend in backends:
-        config = backend.configuration()
-        num_qubits = config.num_qubits
-        if not config.simulator and circ_qubits <= num_qubits:
-            seg = config.processor_type.get('segment', '')
-            key = str(num_qubits)+seg
-            if key not in layouts:
-                layouts[key] = matching_layouts(circ, config.coupling_map,
-                                                call_limit=call_limit)
-            layout_and_error = evaluate_layouts(circ, layouts[key], backend)
-            if any(layout_and_error):
-                layout = layout_and_error[0][0]
-                error = layout_and_error[0][1]
-                best_out.append((layout, backend.name(), error))
-    best_out.sort(key=lambda x: x[2])
-    if successors:
-        return best_out
-    return best_out[0]

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -139,8 +139,8 @@ def evaluate_layouts(circ, layouts, backend, cost_function=None):
     if not isinstance(layouts[0], list):
         layouts = [layouts]
     if cost_function is None:
-        cost_func = default_cost
-    out = cost_func(circ, layouts, backend)
+        cost_function = default_cost
+    out = cost_function(circ, layouts, backend)
     return out
 
 
@@ -163,7 +163,7 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000, cost
         backends = [backends]
 
     if cost_function is None:
-        cost_func = default_cost
+        cost_function = default_cost
 
     layouts = {}
     best_out = []
@@ -179,7 +179,7 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000, cost
                 layouts[key] = matching_layouts(circ, config.coupling_map,
                                                 call_limit=call_limit)
             layout_and_error = evaluate_layouts(circ, layouts[key], backend,
-                                                cost_function=cost_func)
+                                                cost_function=cost_function)
             if any(layout_and_error):
                 layout = layout_and_error[0][0]
                 error = layout_and_error[0][1]

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -141,6 +141,7 @@ def evaluate_layouts(circ, layouts, backend, cost_function=None):
     if cost_function is None:
         cost_function = default_cost
     out = cost_function(circ, layouts, backend)
+    out.sort(key=lambda x: x[1])
     return out
 
 
@@ -200,7 +201,7 @@ def default_cost(circ, layouts, backend):
         backend (IBMQBackend): An IBM Quantum backend instance
 
     Returns:
-        list: Tuples of layouts, backend name, and errors
+        list: Tuples of layout and error
     """
     out = []
     # Make a single layout nested
@@ -224,5 +225,4 @@ def default_cost(circ, layouts, backend):
                 fid *= 1-props.readout_error(layout[q0])
         error = 1-fid
         out.append((layout, error))
-    out.sort(key=lambda x: x[1])
     return out

--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -132,14 +132,14 @@ def evaluate_layouts(circ, layouts, backend, cost_function=None):
         cost_function (callable): Custom cost function, default=None
 
     Returns:
-        list: Tuples of layouts, backend name, and errors
+        list: Tuples of layout, backend name, and cost
     """
     if not any(layouts):
         return []
     if not isinstance(layouts[0], list):
         layouts = [layouts]
     if cost_function is None:
-       cost_func = default_cost
+        cost_func = default_cost
     out = cost_func(circ, layouts, backend)
     return out
 
@@ -163,7 +163,7 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000, cost
         backends = [backends]
 
     if cost_function is None:
-       cost_func = default_cost
+        cost_func = default_cost
 
     layouts = {}
     best_out = []
@@ -178,7 +178,8 @@ def best_overall_layout(circ, backends, successors=False, call_limit=10000, cost
             if key not in layouts:
                 layouts[key] = matching_layouts(circ, config.coupling_map,
                                                 call_limit=call_limit)
-            layout_and_error = evaluate_layouts(circ, layouts[key], backend, cost_function=cost_func)
+            layout_and_error = evaluate_layouts(circ, layouts[key], backend,
+                                                cost_function=cost_func)
             if any(layout_and_error):
                 layout = layout_and_error[0][0]
                 error = layout_and_error[0][1]
@@ -195,7 +196,7 @@ def default_cost(circ, layouts, backend):
 
     Parameters:
         circ (QuantumCircuit): circuit of interest
-        layouts (list): Specified layouts
+        layouts (list of lists): List of specified layouts
         backend (IBMQBackend): An IBM Quantum backend instance
 
     Returns:

--- a/mapomatic/tests/test_best_layout_custom.py
+++ b/mapomatic/tests/test_best_layout_custom.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 """Test best mappings"""
 import numpy as np
-from qiskit import transpile, QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit import transpile, QuantumCircuit
 from qiskit.test.mock import FakeBelem, FakeQuito, FakeLima
 
 import mapomatic as mm

--- a/mapomatic/tests/test_best_layout_custom.py
+++ b/mapomatic/tests/test_best_layout_custom.py
@@ -75,7 +75,7 @@ def test_best_mapping_ghz_state_deflate_multiple_registers():
 def cost_func(circ, layouts, backend):
     """
     A custom cost function that includes T1 and T2 computed during idle periods
-    
+
     Parameters:
         circ (QuantumCircuit): circuit of interest
         layouts (list of lists): List of specified layouts
@@ -133,7 +133,7 @@ def idle_error(time, t1, t2):
     Parameters:
         time (float): Delay time in sec
         t1 (float): T1 time in sec
-        t2, (float): T2 time in sec
+        t2 (float): T2 time in sec
     Returns:
         float: Idle error
     """

--- a/mapomatic/tests/test_best_layout_custom.py
+++ b/mapomatic/tests/test_best_layout_custom.py
@@ -21,8 +21,8 @@ def test_custom_cost_function():
     """Test custom cost functions work"""
     qc = QuantumCircuit(3)
     qc.h(0)
-    qc.cx(0,1)
-    qc.cx(0,2)
+    qc.cx(0, 1)
+    qc.cx(0, 2)
     qc.measure_all()
 
     trans_qc = transpile(qc, FakeBelem(), seed_transpiler=1234)

--- a/mapomatic/tests/test_best_layout_custom.py
+++ b/mapomatic/tests/test_best_layout_custom.py
@@ -1,0 +1,145 @@
+# This code is part of Mapomatic.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Test best mappings"""
+import numpy as np
+from qiskit import transpile, QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.test.mock import FakeBelem, FakeQuito, FakeLima
+
+import mapomatic as mm
+
+
+def test_best_mapping_ghz_state_full_device_multiple_qregs():
+    """Test best mappings with multiple registers"""
+    qr_a = QuantumRegister(2)
+    qr_b = QuantumRegister(3)
+    qc = QuantumCircuit(qr_a, qr_b)
+    qc.h(qr_a[0])
+    qc.cx(qr_a[0], qr_a[1])
+    qc.cx(qr_a[0], qr_b[0])
+    qc.cx(qr_a[0], qr_b[1])
+    qc.cx(qr_a[0], qr_b[2])
+    qc.measure_all()
+    trans_qc = transpile(qc, FakeLima(), seed_transpiler=102442)
+    backends = [FakeBelem(), FakeQuito(), FakeLima()]
+    res = mm.best_overall_layout(trans_qc, backends, successors=True,
+                                 cost_function=cost_func)
+    expected_res = [
+        ([2, 1, 0, 3, 4], 'fake_belem', 0.4150109526706456),
+        ([0, 1, 2, 3, 4], 'fake_lima', 0.46177764990686654),
+        ([2, 1, 0, 3, 4], 'fake_quito', 0.6335024069223241)
+    ]
+    for index, expected in enumerate(expected_res):
+        assert res[index][0] == expected[0]
+        assert res[index][1] == expected[1]
+        assert np.allclose(res[index][2], expected[2])
+
+
+def test_best_mapping_ghz_state_deflate_multiple_registers():
+    """Test best mappings with multiple registers with deflate"""
+    qr_a = QuantumRegister(2)
+    qr_b = QuantumRegister(2)
+    cr_a = ClassicalRegister(2)
+    cr_b = ClassicalRegister(2)
+    qc = QuantumCircuit(qr_a, qr_b, cr_a, cr_b)
+    qc.h(qr_a[0])
+    qc.cx(qr_a[0], qr_a[1])
+    qc.cx(qr_a[0], qr_b[0])
+    qc.cx(qr_a[0], qr_b[1])
+    qc.measure(qr_a, cr_b)
+    qc.measure(qr_b, cr_a)
+    trans_qc = transpile(qc, FakeLima(), seed_transpiler=102442)
+    small_circ = mm.deflate_circuit(trans_qc)
+    backends = [FakeBelem(), FakeQuito(), FakeLima()]
+    res = mm.best_overall_layout(small_circ, backends, successors=True,
+                                 cost_function=cost_func)
+    expected_res = [
+        ([3, 1, 0, 2], 'fake_lima', 0.16555704545051042),
+        ([3, 1, 0, 2], 'fake_belem', 0.21497431066677175),
+        ([3, 1, 2, 0], 'fake_quito', 0.35663459001880293)
+    ]
+    for index, expected in enumerate(expected_res):
+        assert res[index][0] == expected[0]
+        assert res[index][1] == expected[1]
+        assert np.allclose(res[index][2], expected[2])
+
+
+def cost_func(circ, layouts, backend):
+    """
+    A custom cost function that includes T1 and T2 computed during idle periods
+    
+    Parameters:
+        circ (QuantumCircuit): circuit of interest
+        layouts (list of lists): List of specified layouts
+        backend (IBMQBackend): An IBM Quantum backend instance
+
+    Returns:
+        list: Tuples of layout and cost
+    """
+    out = []
+    props = backend.properties()
+    dt = backend.configuration().dt
+    num_qubits = backend.configuration().num_qubits
+    t1s = [props.qubit_property(qq, 'T1')[0] for qq in range(num_qubits)]
+    t2s = [props.qubit_property(qq, 'T2')[0] for qq in range(num_qubits)]
+    for layout in layouts:
+        sch_circ = transpile(circ, backend, initial_layout=layout,
+                             optimization_level=0, scheduling_method='alap')
+        error = 0
+        fid = 1
+        touched = set()
+        for item in sch_circ._data:
+            if item[0].name == 'cx':
+                q0 = sch_circ.find_bit(item[1][0]).index
+                q1 = sch_circ.find_bit(item[1][1]).index
+                fid *= (1-props.gate_error('cx', [q0, q1]))
+                touched.add(q0)
+                touched.add(q1)
+
+            elif item[0].name in ['sx', 'x']:
+                q0 = sch_circ.find_bit(item[1][0]).index
+                fid *= 1-props.gate_error(item[0].name, q0)
+                touched.add(q0)
+
+            elif item[0].name == 'measure':
+                q0 = sch_circ.find_bit(item[1][0]).index
+                fid *= 1-props.readout_error(q0)
+                touched.add(q0)
+
+            elif item[0].name == 'delay':
+                q0 = sch_circ.find_bit(item[1][0]).index
+                # Ignore delays that occur before gates
+                # This assumes you are in ground state and errors
+                # do not occur.
+                if q0 in touched:
+                    time = item[0].duration * dt
+                    fid *= 1-idle_error(time, t1s[q0], t2s[q0])
+
+        error = 1-fid
+        out.append((layout, error))
+        return out
+
+
+def idle_error(time, t1, t2):
+    """Compute the approx. idle error from T1 and T2
+    Parameters:
+        time (float): Delay time in sec
+        t1 (float): T1 time in sec
+        t2, (float): T2 time in sec
+    Returns:
+        float: Idle error
+    """
+    t2 = min(t1, t2)
+    rate1 = 1/t1
+    rate2 = 1/t2
+    p_reset = 1-np.exp(-time*rate1)
+    p_z = (1-p_reset)*(1-np.exp(-time*(rate2-rate1)))/2
+    return p_z + p_reset


### PR DESCRIPTION
Adds the ability to define custom cost functions easily.

The signiture is:

```python
def cost_func(circ, layouts, backend):
    """
    Parameters:
        circ (QuantumCircuit): circuit of interest
        layouts (list of lists): List of specified layouts
        backend (IBMQBackend): An IBM Quantum backend instance

    Returns:
        list: Tuples of layout and cost
    """

```