### PR TITLE
Allow a backend instance in matching layouts

### DIFF
--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -39,13 +39,18 @@ def matching_layouts(circ, cmap, strict_direction=False, call_limit=10000):
 
     Parameters:
         circ (QuantumCircuit): Input quantum circuit
-        cmap (list): Coupling map
+        cmap (list or IBMQBackend): Coupling map or backend instance
         strict_direction (bool): Use directed coupling
         call_limit (int): Max number of calls to VF2 mapper
 
     Returns:
         list: Found mappings.
     """
+    if isinstance(cmap, list):
+        cmap = CouplingMap(cmap)
+    else:
+        cmap = CouplingMap(cmap.configuration().coupling_map)
+
     dag = circuit_to_dag(circ)
     qubits = dag.qubits
     qubit_indices = {qubit: index for index, qubit in enumerate(qubits)}
@@ -55,7 +60,7 @@ def matching_layouts(circ, cmap, strict_direction=False, call_limit=10000):
         len_args = len(node.qargs)
         if len_args == 2:
             interactions.append((qubit_indices[node.qargs[0]], qubit_indices[node.qargs[1]]))
-    cmap = CouplingMap(cmap)
+
     if strict_direction:
         cm_graph = cmap.graph
         im_graph = PyDiGraph(multigraph=False)

--- a/mapomatic/tests/test_matching_layout.py
+++ b/mapomatic/tests/test_matching_layout.py
@@ -1,0 +1,32 @@
+# This code is part of Mapomatic.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Test best mappings"""
+
+from qiskit import QuantumCircuit
+from qiskit.test.mock import FakeMontreal
+
+import mapomatic as mm
+
+
+def test_matching_layout_backend_pass():
+    """Test that I can pass a backend to matching layouts"""
+    qc = QuantumCircuit(4)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(0, 2)
+    qc.cx(0, 3)
+    qc.measure_all()
+
+    backend = FakeMontreal()
+    mappings1 = mm.matching_layouts(qc, backend)
+    mappings2 = mm.matching_layouts(qc, backend.configuration().coupling_map)
+    assert mappings1 == mappings2


### PR DESCRIPTION
I forgot to change `matching_layouts` to take a backend instance directly