### PR TITLE
Increase default call_limit to 1e5

### DIFF
--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -35,7 +35,7 @@ from qiskit.transpiler.coupling import CouplingMap
 from qiskit.providers.backend import BackendV1, BackendV2
 
 
-def matching_layouts(circ, cmap, strict_direction=False, call_limit=10000):
+def matching_layouts(circ, cmap, strict_direction=False, call_limit=100000):
     """Matching for a circuit onto a given topology (coupling map)
 
     Parameters:

--- a/mapomatic/tests/test_best_layout.py
+++ b/mapomatic/tests/test_best_layout.py
@@ -31,11 +31,10 @@ def test_best_mapping_ghz_state_full_device_multiple_qregs():
     trans_qc = transpile(qc, FakeLima(), seed_transpiler=102442)
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
     res = mm.best_overall_layout(trans_qc, backends, successors=True)
-    expected_res = [
-        ([0, 1, 2, 3, 4], 'fake_lima', 0.2948138379010775),
-        ([0, 1, 2, 3, 4], 'fake_belem', 0.3099503939385677),
-        ([2, 1, 0, 3, 4], 'fake_quito', 0.5360875795095078)
-    ]
+    expected_res = [([0, 1, 2, 3, 4], 'fake_belem', 0.28117480552733065),
+                    ([0, 1, 2, 3, 4], 'fake_lima', 0.2813874429560348),
+                    ([2, 1, 0, 3, 4], 'fake_quito', 0.5101783470040677)
+                   ]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]
         assert res[index][1] == expected[1]
@@ -59,11 +58,10 @@ def test_best_mapping_ghz_state_deflate_multiple_registers():
     small_circ = mm.deflate_circuit(trans_qc)
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
     res = mm.best_overall_layout(small_circ, backends, successors=True)
-    expected_res = [
-        ([3, 1, 0, 2], 'fake_lima', 0.1466490604029853),
-        ([0, 1, 3, 2], 'fake_belem', 0.18757249682201993),
-        ([3, 1, 2, 0], 'fake_quito', 0.3202504720264385)
-    ]
+    expected_res = [([0, 1, 2, 3], 'fake_lima', 0.13133288833556145),
+                    ([2, 1, 3, 0], 'fake_belem', 0.16103780370236487),
+                    ([3, 1, 0, 2], 'fake_quito', 0.29391929118639826)
+                   ]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]
         assert res[index][1] == expected[1]

--- a/mapomatic/tests/test_best_layout.py
+++ b/mapomatic/tests/test_best_layout.py
@@ -33,8 +33,7 @@ def test_best_mapping_ghz_state_full_device_multiple_qregs():
     res = mm.best_overall_layout(trans_qc, backends, successors=True)
     expected_res = [([0, 1, 2, 3, 4], 'fake_belem', 0.28117480552733065),
                     ([0, 1, 2, 3, 4], 'fake_lima', 0.2813874429560348),
-                    ([2, 1, 0, 3, 4], 'fake_quito', 0.5101783470040677)
-                   ]
+                    ([2, 1, 0, 3, 4], 'fake_quito', 0.5101783470040677)]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]
         assert res[index][1] == expected[1]
@@ -60,8 +59,7 @@ def test_best_mapping_ghz_state_deflate_multiple_registers():
     res = mm.best_overall_layout(small_circ, backends, successors=True)
     expected_res = [([0, 1, 2, 3], 'fake_lima', 0.13133288833556145),
                     ([2, 1, 3, 0], 'fake_belem', 0.16103780370236487),
-                    ([3, 1, 0, 2], 'fake_quito', 0.29391929118639826)
-                   ]
+                    ([3, 1, 0, 2], 'fake_quito', 0.29391929118639826)]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]
         assert res[index][1] == expected[1]

--- a/mapomatic/tests/test_best_layout_custom.py
+++ b/mapomatic/tests/test_best_layout_custom.py
@@ -30,11 +30,9 @@ def test_custom_cost_function():
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
     res = mm.best_overall_layout(small_qc, backends, successors=True,
                                  cost_function=cost_func)
-    expected_res = [
-                    ([3, 1, 0], 'fake_lima', 0.16209248467419868),
-                    ([3, 1, 0], 'fake_belem', 0.19277653702222508),
-                    ([3, 1, 0], 'fake_quito', 0.2999498671292371)
-                   ]
+    expected_res = [([3, 1, 0], 'fake_lima', 0.11830389787680795),
+                    ([3, 1, 0], 'fake_belem', 0.14358751944450088),
+                    ([3, 1, 0], 'fake_quito', 0.18092141250599547)]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]
         assert res[index][1] == expected[1]


### PR DESCRIPTION
We were missing some layout options by having not enough calls.  This fixes that.  At some point will need to figure out a heuristic for this.  I am also wondering if the algorithm itself can be improved upon in our specific case because we do not have generic graphs, but rather repeatedly unit cells with symmetry.