### PR TITLE
[WIP] Allow for barriers that span over unused qubits

### DIFF
--- a/mapomatic/circuits.py
+++ b/mapomatic/circuits.py
@@ -44,12 +44,18 @@ def deflate_circuit(input_circ):
 
     new_qc = QuantumCircuit(num_reduced_qubits, num_reduced_clbits)
     for item in input_circ.data:
-        if all(qubit in active_qubits for qubit in item[1]):
+        # Find active qubits used by instruction (if any)
+        used_active_set = []
+        for qubit in item[1]:
+            if qubit in active_qubits:
+                used_active_set.append(qubit)
+        # If any active qubits used, add to deflated circuit
+        if any(used_active_set):
             ref = getattr(new_qc, item[0].name)
             params = item[0].params
-            qargs = [new_qc.qubits[active_map[qubit]] for qubit in item[1]]
+            qargs = [new_qc.qubits[active_map[qubit]] for qubit in used_active_set]
             cargs = [new_qc.clbits[active_map[clbit]] for clbit in item[2]]
-            ref(*params, *qargs, *cargs)
+        ref(*params, *qargs, *cargs)
 
     return new_qc
 


### PR DESCRIPTION
Fixes an issue where barriers over more than the active set are not added to the deflated circuit.