### PR TITLE
Add global phase to deflated and inflated circuits

### DIFF
--- a/mapomatic/circuits.py
+++ b/mapomatic/circuits.py
@@ -54,7 +54,7 @@ def deflate_circuit(input_circ):
             qargs = [new_qc.qubits[active_map[qubit]] for qubit in used_active_set]
             cargs = [new_qc.clbits[active_map[clbit]] for clbit in item[2]]
             ref(*params, *qargs, *cargs)
-
+    new_qc.global_phase = input_circ.global_phase
     return new_qc
 
 
@@ -111,4 +111,5 @@ def inflate_circuit(input_circ, layout, backend):
         qargs = [layout[input_circ.find_bit(idx).index] for idx in item[1]]
         cargs = item[2]
         ref(*params, *qargs, *cargs)
+    new_qc.global_phase = input_circ.global_phase
     return new_qc

--- a/mapomatic/tests/test_deflate_barriers.py
+++ b/mapomatic/tests/test_deflate_barriers.py
@@ -42,6 +42,8 @@ def test_deflate_barriers1():
     ans_qc.cx(1, 2)
     ans_qc.cx(2, 3)
     ans_qc.barrier()
+    # Transpiler does not preserve global phase of input circuit
+    ans_qc.global_phase = trans_qc.global_phase
 
     assert small_qc == ans_qc
 


### PR DESCRIPTION
Deflated and inflated circuits were missing the global phases from the parent circuits