### PR TITLE
Update test values that were broken by Terra transpilation changes

### DIFF
--- a/mapomatic/tests/test_best_layout.py
+++ b/mapomatic/tests/test_best_layout.py
@@ -31,9 +31,9 @@ def test_best_mapping_ghz_state_full_device_multiple_qregs():
     trans_qc = transpile(qc, FakeLima(), seed_transpiler=102442)
     backends = [FakeBelem(), FakeQuito(), FakeLima()]
     res = mm.best_overall_layout(trans_qc, backends, successors=True)
-    expected_res = [([0, 1, 2, 3, 4], 'fake_belem', 0.28117480552733065),
-                    ([0, 1, 2, 3, 4], 'fake_lima', 0.2813874429560348),
-                    ([2, 1, 0, 3, 4], 'fake_quito', 0.5101783470040677)]
+    expected_res = [([2, 1, 0, 3, 4], 'fake_belem', 0.22510067603405248),
+                    ([0, 1, 2, 3, 4], 'fake_lima', 0.23799533658490646),
+                    ([0, 1, 2, 3, 4], 'fake_quito', 0.41031068269132387)]
     for index, expected in enumerate(expected_res):
         assert res[index][0] == expected[0]
         assert res[index][1] == expected[1]


### PR DESCRIPTION
Fixes #52 .

The test was broken by https://github.com/Qiskit/qiskit-terra/pull/8552.

Note that this change itself is broken by https://github.com/Qiskit/qiskit-terra/pull/9026, so the test will need to be updated again for the version of Terra that includes that change. Perhaps this indicates that the test should be modified. Apparently, the output of the call
```python
transpile(qc, FakeLima(), seed_transpiler=102442)
```
can change with new versions of Terra. We should also consider pinning the version of Terra used by mapomatic.