### PR TITLE
Fix delays returning no scores

### DIFF
--- a/mapomatic/layouts.py
+++ b/mapomatic/layouts.py
@@ -151,7 +151,8 @@ def evaluate_layouts(circ, layouts, backend, cost_function=None):
     """
     if not any(layouts):
         return []
-    circuit_gates = set(circ.count_ops()).difference({'barrier', 'reset', 'measure'})
+    circuit_gates = set(circ.count_ops()).difference({'barrier', 'reset',
+                                                      'measure', 'delay'})
     if not circuit_gates.issubset(backend.configuration().basis_gates):
         return []
     if not isinstance(layouts[0], list):


### PR DESCRIPTION
fixes #72 

This adds `delay` to the list of instructions that a circuit can have after transpilation.  Previously a `delay` was causing MM to think the circuit had not been transpiled yet.